### PR TITLE
Ensuring stacktrace doesn't get lost

### DIFF
--- a/src/p-compose.js
+++ b/src/p-compose.js
@@ -23,7 +23,7 @@ const PromiseComposeFactory = Promise => (...fns) => {
   const head = fns[0];
   const rest = fns.slice(1);
 
-  return (...args) => rest.reduce(promiseReducer, Promise.resolve().then(() => head(...args)));
+  return (...args) => rest.reduce(promiseReducer, Promise.resolve(head(...args)));
 };
 
 module.exports = PromiseComposeFactory(Promise);


### PR DESCRIPTION
Hey Guy. Long time no see.

We were running into a issue where it looks like the stack traces were kind of getting swallowed up when using this library and we kind of determined it was from the head function call inside of the anonymous function.

With the previous state the stack traces looked a little something like

```
-Error: oops...
      -    at reject (/home/jdollar/repos/p-compose/test/p-compose.test.js:53:41)
      -    at /home/jdollar/repos/p-compose/src/p-compose.js:26:80
      -    at <anonymous>
```

With this change they look a little something like

```
-Error: oops...
      -    at reject (/home/jdollar/repos/p-compose/test/p-compose.test.js:53:41)
      -    at /home/jdollar/repos/p-compose/src/p-compose.js:26:67
      -    at _callee3$ (/home/jdollar/repos/p-compose/test/p-compose.test.js:59:13)
      -    at tryCatch (/home/jdollar/repos/p-compose/node_modules/regenerator-runtime/runtime.js:62:40)
      -    at Generator.invoke [as _invoke] (/home/jdollar/repos/p-compose/node_modules/regenerator-runtime/runtime.js:296:22)
      -    at Generator.prototype.(anonymous function) [as next] (/home/jdollar/repos/p-compose/node_modules/regenerator-runtime/runtime.js:114:21)
      -    at step (/home/jdollar/repos/p-compose/node_modules/babel-runtime/helpers/asyncToGenerator.js:17:30)
      -    at /home/jdollar/repos/p-compose/node_modules/babel-runtime/helpers/asyncToGenerator.js:35:14
      -    at new Promise (<anonymous>)
      -    at new F (/home/jdollar/repos/p-compose/node_modules/core-js/library/modules/_export.js:36:28)
      -    at Context.<anonymous> (/home/jdollar/repos/p-compose/node_modules/babel-runtime/helpers/asyncToGenerator.js:14:12)
      -    at callFn (/home/jdollar/repos/p-compose/node_modules/mocha/lib/runnable.js:383:21)
      -    at Test.Runnable.run (/home/jdollar/repos/p-compose/node_modules/mocha/lib/runnable.js:375:7)
      -    at Runner.runTest (/home/jdollar/repos/p-compose/node_modules/mocha/lib/runner.js:446:10)
      -    at /home/jdollar/repos/p-compose/node_modules/mocha/lib/runner.js:564:12
      -    at next (/home/jdollar/repos/p-compose/node_modules/mocha/lib/runner.js:360:14)
      -    at /home/jdollar/repos/p-compose/node_modules/mocha/lib/runner.js:370:7
      -    at next (/home/jdollar/repos/p-compose/node_modules/mocha/lib/runner.js:294:14)
      -    at Immediate._onImmediate (/home/jdollar/repos/p-compose/node_modules/mocha/lib/runner.js:338:5)
      -    at runCallback (timers.js:810:20)
      -    at tryOnImmediate (timers.js:768:5)
      -    at processImmediate [as _immediateCallback] (timers.js:745:5)
```

Just wanted to share the love. Do you think there would be any issue moving the head call outside the .then of the promise resolve?